### PR TITLE
Fix deprecation error in PHP 8.1 and remove compatibility with PHP 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.2|^8.0"
+    "php": "^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
@@ -37,5 +37,10 @@
     "syntax": "phpcs"
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": false
+    }
+  }
 }

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-cli-alpine
+FROM php:8.1-cli-alpine
 
 RUN apk add git
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Custom List Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertDeprecationsToExceptions="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="Custom List Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/CustomList.php
+++ b/src/CustomList.php
@@ -12,8 +12,7 @@ use Traversable;
 
 abstract class CustomList implements IteratorAggregate, ArrayAccess, Countable
 {
-    /** @var array */
-    protected $items;
+    protected array $items;
 
     abstract protected function getListType(): string;
 
@@ -37,53 +36,53 @@ abstract class CustomList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * Add item to list as array
      *
-     * @param mixed $key
-     * @param mixed $item
+     * @param mixed $offset
+     * @param mixed $value
      * @return void
      * @throws CustomListTypeErrorException
      */
-    public function offsetSet($key, $item): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
-        $this->checkItemType($item);
+        $this->checkItemType($value);
 
-        if ($key === null) {
-            $this->items[] = $item;
+        if ($offset === null) {
+            $this->items[] = $value;
         } else {
-            $this->items[$key] = $item;
+            $this->items[$offset] = $value;
         }
     }
 
     /**
      * Get item from list with key
      *
-     * @param mixed $key
+     * @param mixed $offset
      * @return mixed
      */
-    public function offsetGet($key)
+    public function offsetGet(mixed $offset): mixed
     {
-        return $this->items[$key];
+        return $this->items[$offset];
     }
 
     /**
      * Checks if the list as an item by key
      *
-     * @param mixed $key
+     * @param mixed $offset
      * @return bool
      */
-    public function offsetExists($key): bool
+    public function offsetExists(mixed $offset): bool
     {
-        return array_key_exists($key, $this->items);
+        return array_key_exists($offset, $this->items);
     }
 
     /**
      * Remove item from list by key
      *
-     * @param mixed $key
+     * @param mixed $offset
      * @return void
      */
-    public function offsetUnset($key): void
+    public function offsetUnset(mixed $offset): void
     {
-        unset($this->items[$key]);
+        unset($this->items[$offset]);
     }
 
     /**
@@ -99,11 +98,11 @@ abstract class CustomList implements IteratorAggregate, ArrayAccess, Countable
     /**
      * Get item by key or all items without it
      *
-     * @param null $key
+     * @param string|null $key
      * @return mixed
      * @throws CustomListKeyNotExistException
      */
-    public function get($key = null)
+    public function get(?string $key = null): mixed
     {
         if ($key !== null) {
             if (!array_key_exists($key, $this->items)) {
@@ -123,7 +122,7 @@ abstract class CustomList implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @throws CustomListTypeErrorException
      */
-    public function add($item): void
+    public function add(mixed $item): void
     {
         $this->checkItemType($item);
 
@@ -150,7 +149,7 @@ abstract class CustomList implements IteratorAggregate, ArrayAccess, Countable
      * @return void
      * @throws CustomListTypeErrorException
      */
-    private function checkItemType($item): void
+    private function checkItemType(mixed $item): void
     {
         $type = $this->getListType();
 


### PR DESCRIPTION
PHP 8.1 returns a PHP Deprecated error.

> PHP Deprecated:  Return type of Letsgoi\CustomList\CustomList::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/current/vendor/letsgoi/custom-list/src/CustomList.php on line 62

To solve it, I modified the implementation of ArrayAccess methods to be compatible with the interface. Also, I drop support for PHP 7. We have been updating out projects to PHP 8.1, so we will not need support for older versions.

I also add `convertDeprecationsToExceptions="true"` to phpunit config.

https://app.shortcut.com/goi/story/7712