### PR TITLE
Check if iterable passed to list is a Traversable object.

### DIFF
--- a/src/CustomList.php
+++ b/src/CustomList.php
@@ -18,7 +18,11 @@ abstract class CustomList implements IteratorAggregate, ArrayAccess, Countable
 
     public function __construct(iterable $items = [])
     {
-        $this->items = (array)$items;
+        if ($items instanceof Traversable) {
+            $this->items = iterator_to_array($items);
+        } else {
+            $this->items = (array)$items;
+        }
 
         $this->checkItems();
     }


### PR DESCRIPTION
Check if iterable passed to list is a Traversable object. In that case, it will be converted to array using iterator_to_array function.
It's useful, for example, when working with Laravel Collections.

https://www.notion.so/e9c7c7b3253c4ece938df6e5834d3a08